### PR TITLE
Sweep: Change the install app button color to green (✓ Sandbox Passed)

### DIFF
--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -126,9 +126,9 @@ export default function CallToAction() {
         <Button
           color="white"
           p={6}
-          colorScheme={"purple"}
-          bg={"purple.400"}
-          _hover={{ bg: "purple.600" }}
+          colorScheme={"green"}
+          bg={"green.400"}
+          _hover={{ bg: "green.600" }}
           onClick={() => window.open("https://github.com/apps/sweep-ai")}
           fontSize={"xl"}
           mb="1rem !important"


### PR DESCRIPTION
# Description
This pull request changes the color of the install app button in the CallToAction component from purple to green. It also updates the hover color accordingly.

# Summary
- Change the install app button color to green in `src/components/CallToAction.tsx`
- Update the hover color to match the new button color

Fixes #573.

---

<details>
<summary><b>🎉 Latest improvements to Sweep:</b></summary>
<ul>
<li>New <a href="https://sweep-trilogy.vercel.app">dashboard</a> launched for real-time tracking of Sweep issues, covering all stages from search to coding.</li>
<li>Integration of OpenAI's latest Assistant API for more efficient and reliable code planning and editing, improving speed by 3x.</li>
<li>Use the <a href="https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github">GitHub issues extension</a> for creating Sweep issues directly from your editor.</li>
</ul>
</details>


---

### 💡 To get Sweep to edit this pull request, you can:
* Comment below, and Sweep can edit the entire PR
* Comment on a file, Sweep will only modify the commented file
* Edit the original issue to get Sweep to recreate the PR from scratch